### PR TITLE
Added support for precision scrolling (e.g. mac trackpads now work)

### DIFF
--- a/addons/control_camera3d/nodes/control_camera_3d.gd
+++ b/addons/control_camera3d/nodes/control_camera_3d.gd
@@ -141,3 +141,8 @@ func _unhandled_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_WHEEL_DOWN:
 		if global_position.distance_to(pivot_pos) < zoom_out:
 			translate_object_local(Vector3.FORWARD * -_WHEEL_SENSITIVITY * zoom_speed)
+	
+	# On devices with precision scrolling (e.g. Mac), event.delta is a Vector2 with x and y
+	# scrolling deltas.
+	if event is InputEventPanGesture:
+		translate_object_local(-Vector3.FORWARD * _WHEEL_SENSITIVITY * zoom_speed * event.delta.y)


### PR DESCRIPTION
Hi, thanks for this addon!

I noticed that scrolling to zoom did not work on my Mac. It looks like macs require support for precision scrolling (i.e. the event type is `InputEventPanGesture` (which provides a Vector2 with xy scroll amounts [1]) rather than the binary `InputEventMouseButton`. I implemented support for this, and it works on my mac now. I cannot test this on other OSes right now, but the change is very simple and I cannot imagine it will cause any degredation.

1: https://docs.godotengine.org/en/stable/classes/class_inputeventpangesture.html